### PR TITLE
Removed SharePoint links tab

### DIFF
--- a/app/views/beta-sprint-1/project-overview.html
+++ b/app/views/beta-sprint-1/project-overview.html
@@ -28,9 +28,6 @@
           <a class="app-sub-navigation__link" href="project-task-list.html">Task list</a>
         </li>
         <li class="app-sub-navigation__item">
-          <a class="app-sub-navigation__link" href="#">Sharepoint links</a>
-        </li>
-        <li class="app-sub-navigation__item">
           <a class="app-sub-navigation__link" href="#">Project notes</a>
         </li>
       </ul>

--- a/app/views/beta-sprint-1/project-task-list.html
+++ b/app/views/beta-sprint-1/project-task-list.html
@@ -28,9 +28,6 @@
           <a class="app-sub-navigation__link" aria-current="page" href="#">Task list</a>
         </li>
         <li class="app-sub-navigation__item">
-          <a class="app-sub-navigation__link" href="#">Sharepoint links</a>
-        </li>
-        <li class="app-sub-navigation__item">
           <a class="app-sub-navigation__link" href="#">Project notes</a>
         </li>
       </ul>


### PR DESCRIPTION
I suggest removing the SharePoint tab based on the user feedback we received - search 'SharePoint' in https://educationgovuk.sharepoint.com/:p:/r/sites/ServiceDeliveryDirectorate/_layouts/15/Doc.aspx?sourcedoc=%7B78E8E064-C416-439F-8A3F-7EAB358019CB%7D&file=FSS%20User%20research%20playbacks.pptx&action=edit&mobileredirect=true